### PR TITLE
Update `uri` to the latest version.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       openssl (~> 3.0, >= 3.0.0)
       rack (~> 3.0)
       starry (~> 0.2)
-      uri (~> 0.12, >= 0.12.0)
+      uri (~> 1.0, >= 1.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -81,7 +81,7 @@ GEM
     starry (0.2.0)
       base64
     unicode-display_width (2.5.0)
-    uri (0.13.0)
+    uri (1.0.2)
 
 PLATFORMS
   arm64-darwin-21

--- a/linzer.gemspec
+++ b/linzer.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ed25519", "~> 1.3", ">= 1.3.0"
   spec.add_runtime_dependency "starry", "~> 0.2"
   spec.add_runtime_dependency "rack", "~> 3.0"
-  spec.add_runtime_dependency "uri", "~> 0.12", ">= 0.12.0"
+  spec.add_runtime_dependency "uri", "~> 1.0", ">= 1.0.2"
 end


### PR DESCRIPTION
It has recently reached 1.0.

Given this is part of the standard library / default gems of ruby most gems do not have very rigorous version requirements on this, but I did experience a conflict when trying to use linzer with the `httpx` gem.