### PR TITLE
Add `rack` 2 backwards compat

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     linzer (0.6.0)
       ed25519 (~> 1.3, >= 1.3.0)
       openssl (~> 3.0, >= 3.0.0)
-      rack (~> 3.0)
+      rack (>= 2.2, < 4.0)
       starry (~> 0.2)
       uri (~> 0.12, >= 0.12.0)
 
@@ -25,7 +25,7 @@ GEM
       ast (~> 2.4.1)
       racc
     racc (1.7.3)
-    rack (3.0.11)
+    rack (3.1.8)
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.0)

--- a/lib/linzer/request.rb
+++ b/lib/linzer/request.rb
@@ -11,7 +11,8 @@ module Linzer
       request_method = Rack.const_get(verb.upcase)
       args = {
         "REQUEST_METHOD" => request_method,
-        "PATH_INFO"      => uri.to_str
+        "PATH_INFO"      => uri.to_str,
+        "rack.input"     => StringIO.new
       }
 
       Rack::Request.new(build_rack_env(headers).merge(args))

--- a/linzer.gemspec
+++ b/linzer.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "openssl", "~> 3.0", ">= 3.0.0"
   spec.add_runtime_dependency "ed25519", "~> 1.3", ">= 1.3.0"
   spec.add_runtime_dependency "starry", "~> 0.2"
-  spec.add_runtime_dependency "rack", "~> 3.0"
+  spec.add_runtime_dependency "rack", ">= 2.2", "< 4.0"
   spec.add_runtime_dependency "uri", "~> 0.12", ">= 0.12.0"
 end


### PR DESCRIPTION
Fixes #2.

Please note that I had to add a tiny little thing to make this work with rack 2: rack 2 two requires a `rack.input`, other than that it is 100% compatible with version 3 when it comes to the methods that linzer uses.

I did make sure the specs pass with rack 2 and 3, but this PR does not include any fancy multi-version test setup (e.g. with the `appraisal` gem).

I consider this to be more of a stop-gap measure for now. Ideally I would like the requirement on rack be dropped altogether, but I will need to write this up in an issue before that can be discussed in any detail.

Also, if you do not like this change and/or do not wish to relax the version requirement in this or any other way, I totally understand this.