### PR TITLE
Remove dependency on `ed25519` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem "rake", "~> 13.0"
 
 gem "rspec", "~> 3.0"
 
+gem "securerandom"
+
 gem "standard", "~> 1.3"
 
 gem "simplecov", require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     linzer (0.6.0)
-      ed25519 (~> 1.3, >= 1.3.0)
       openssl (~> 3.0, >= 3.0.0)
       rack (~> 3.0)
       starry (~> 0.2)
@@ -15,7 +14,6 @@ GEM
     base64 (0.2.0)
     diff-lcs (1.5.1)
     docile (1.4.0)
-    ed25519 (1.3.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
@@ -60,6 +58,7 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -92,6 +91,7 @@ DEPENDENCIES
   linzer!
   rake (~> 13.0)
   rspec (~> 3.0)
+  securerandom
   simplecov
   standard (~> 1.3)
 

--- a/README.md
+++ b/README.md
@@ -97,13 +97,10 @@ response = http.post("/some_uri", "data", headers.merge(signature.to_h))
 ### To verify a valid signature:
 
 ```ruby
-test_ed25519_key_pub = Base64.strict_encode64(key.material.verify_key.to_bytes)
-# => "EUra7KsJ8B/lSZJVhDaopMycmZ6T7KtJqKVNJTHKIw0="
+test_ed25519_key_pub = key.material.public_to_pem
+# => "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAK1ZrC4JqC356pRsUiLVJdFZ3dAjo909VfWs1li33MCQ=\n-----END PUBLIC KEY-----\n"
 
-raw_pubkey = Base64.strict_decode64(test_ed25519_key_pub)
-# => "\xB1rM\xFFR\x1F\xDDw\x00\x89\..."
-
-pubkey = Linzer.new_ed25519_public_key(raw_pubkey, "some-key-ed25519")
+pubkey = Linzer.new_ed25519_public_key(test_ed25519_key_pub, "some-key-ed25519")
 # => #<Linzer::Ed25519::Key:0x00000fe19b9384b0
 
 # if you have to, there is a helper method to build a request object on the server side

--- a/lib/linzer/ed25519.rb
+++ b/lib/linzer/ed25519.rb
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
-require "ed25519"
-
 module Linzer
   module Ed25519
     class Key < Linzer::Key
       def sign(data)
-        material.sign(data)
+        material.sign(nil, data)
       end
 
       def verify(signature, data)
-        verify_key = material.is_a?(::Ed25519::SigningKey) ? material.verify_key : material
-        verify_key.verify(signature, data)
-      rescue ::Ed25519::VerifyError
-        false
+        material.verify(nil, signature, data)
       end
     end
   end

--- a/lib/linzer/key/helper.rb
+++ b/lib/linzer/key/helper.rb
@@ -33,18 +33,17 @@ module Linzer
       end
 
       def generate_ed25519_key(key_id = nil)
-        material = ::Ed25519::SigningKey.generate
+        material = OpenSSL::PKey.generate_key("ed25519")
         Linzer::Ed25519::Key.new(material, id: key_id)
       end
 
       def new_ed25519_key(material, key_id = nil)
-        key = ::Ed25519::SigningKey.new(material)
+        key = OpenSSL::PKey.read(material)
         Linzer::Ed25519::Key.new(key, id: key_id)
       end
 
       def new_ed25519_public_key(material, key_id = nil)
-        key = ::Ed25519::VerifyKey.new(material)
-        Linzer::Ed25519::Key.new(key, id: key_id)
+        new_ed25519_key(material, key_id)
       end
 
       # https://www.rfc-editor.org/rfc/rfc4492.html#appendix-A

--- a/linzer.gemspec
+++ b/linzer.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "openssl", "~> 3.0", ">= 3.0.0"
-  spec.add_runtime_dependency "ed25519", "~> 1.3", ">= 1.3.0"
   spec.add_runtime_dependency "starry", "~> 0.2"
   spec.add_runtime_dependency "rack", "~> 3.0"
   spec.add_runtime_dependency "uri", "~> 0.12", ">= 0.12.0"

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe "README usage" do
   let(:key) { Linzer.generate_ed25519_key }
 
   let(:pubkey) do
-    exported_pubkey = Base64.strict_encode64(key.material.verify_key.to_bytes)
-    raw_pubkey      = Base64.strict_decode64(exported_pubkey)
-    Linzer.new_ed25519_public_key(raw_pubkey, "some-key-ed25519")
+    exported_pubkey = key.material.public_to_pem
+    Linzer.new_ed25519_public_key(exported_pubkey, "some-key-ed25519")
   end
 
   describe "HTTP request examples" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@
 require "simplecov"
 SimpleCov.start
 
+require "securerandom"
+
 require "linzer"
 require_relative "rfc9421_examples"
 


### PR DESCRIPTION
`OpenSSL` supports ed25519 just fine and since it is already used for other algorithms I thought this might be a nice way to make linzer a tiny bit more light-weight.