### PR TITLE
Allow validating the `created` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ Linzer.verify(pubkey, message, signature)
 # => true
 ```
 
+To mitigate the risk of "replay attacks" (i.e. an attacker capturing a message with a valid signature and re-sending it at a later point) applications may want to validate the `created` parameter of the signature. Linzer can do this automatically when given the optional `no_older_than` keyword argument:
+
+```ruby
+Linzer.verify(pubkey, message, signature, no_older_than: 500)
+```
+
+`no_older_than` expects a number of seconds, but you can pass anything that to responds to `#to_i`, including an `ActiveSupport::Duration`.
+`::verify` will raise if the `created` parameter of the signature is older than the given number of seconds.
+
 ### What if an invalid signature if verified?
 
 ```ruby

--- a/lib/linzer.rb
+++ b/lib/linzer.rb
@@ -32,8 +32,8 @@ module Linzer
       Linzer::Request.build(verb, uri, params, headers)
     end
 
-    def verify(pubkey, message, signature)
-      Linzer::Verifier.verify(pubkey, message, signature)
+    def verify(pubkey, message, signature, no_older_than: nil)
+      Linzer::Verifier.verify(pubkey, message, signature, no_older_than: no_older_than)
     end
 
     def sign(key, message, components, options = {})

--- a/lib/linzer/signature.rb
+++ b/lib/linzer/signature.rb
@@ -14,6 +14,15 @@ module Linzer
     alias_method :components, :metadata
     alias_method :bytes, :value
 
+    def created
+      parameters["created"]
+    end
+
+    def older_than?(seconds)
+      raise Error.new "Signature is missing the `created` parameter" if created.nil?
+      (Time.now.to_i - created) > seconds
+    end
+
     def to_h
       {
         "signature" => Starry.serialize({label => value}),

--- a/lib/linzer/verifier.rb
+++ b/lib/linzer/verifier.rb
@@ -5,11 +5,15 @@ module Linzer
     class << self
       include Common
 
-      def verify(key, message, signature)
+      def verify(key, message, signature, no_older_than: nil)
         validate message, key, signature
 
         parameters = signature.parameters
         components = signature.components
+
+        if no_older_than && (Time.now.to_i - parameters["created"]) > no_older_than.to_i
+          raise Error.new "Signature created more than #{no_older_than} seconds ago"
+        end
 
         signature_base = signature_base(message, components, parameters)
 

--- a/spec/linzer_spec.rb
+++ b/spec/linzer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Linzer do
     signature = :some_signature
 
     expect(Linzer::Verifier).to receive(:verify)
-      .with(pubkey, message, signature)
+      .with(pubkey, message, signature, no_older_than: nil)
 
     Linzer.verify(pubkey, message, signature)
   end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe "README usage" do
       expect(Linzer.verify(pubkey, message, valid_signature)).to eq(true)
     end
 
+    it "allows validating the `created` parameter" do
+      signed_headers   = headers.merge(signature.to_h)
+      valid_signature  = Linzer::Signature.build(signed_headers)
+      p valid_signature.parameters
+
+      expect(Linzer.verify(pubkey, message, valid_signature, no_older_than: 300)).to eq(true)
+    end
+
     it "cannot verify an invalid signature" do
       random_signature = build_random_signature("sig1")
       signed_headers   = signature.to_h.merge({"signature" => random_signature})


### PR DESCRIPTION
Fixes #7 

This is a first attempt to add validation of the `created` parameter. This can be used to mitigate the risk of replay attacks.

This is just a first suggestion. Let me know what you think, I am more than happy to change the API, move stuff around etc.