### PR TITLE
Fix buggy request example test setup in RSA spec

### DIFF
--- a/spec/request_helper.rb
+++ b/spec/request_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Linzer
+  module Test
+    module RequestHelper
+      extend self
+
+      def example_proxy_request
+        uri = URI("http://origin.host.internal.example/foo?param=Value&Pet=dog")
+        headers = {
+          "date"           => "Tue, 20 Apr 2021 02:07:56 GMT",
+          "forwarded"      => "for=192.0.2.123;host=example.com;proto=https",
+          "content-digest" => "sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:",
+          "content-length" => "18"
+        }
+        request = Net::HTTP::Post.new(uri, headers)
+        request.content_type = "application/json"
+        request.body = '{"hello": "world"}'
+        request
+      end
+    end
+  end
+end

--- a/spec/rsa_spec.rb
+++ b/spec/rsa_spec.rb
@@ -12,17 +12,7 @@ end
 RSpec.describe Linzer::Signer do
   context "with RSA" do
     let(:request) do
-      request_data = Linzer::RFC9421::Examples.test_request_data
-      path = request_data[:http]["path"]
-      headers = request_data[:headers].merge({
-        "host" => "origin.host.internal.example",
-        "forwarded" => "for=192.0.2.123;host=example.com;proto=https"
-      })
-      request = Linzer::Test::RackHelper.new_request(:post, path, {}, headers)
-      # Workaround the fact that `rack` reports a different `@authority`
-      # than this example from RFC9421 expects
-      allow(request).to receive(:authority).and_return("origin.host.internal.example")
-      request
+      Linzer::Test::RequestHelper.example_proxy_request
     end
 
     let(:key_material) { Linzer::RFC9421::Examples.test_key_rsa }
@@ -52,16 +42,7 @@ end
 RSpec.describe Linzer::Verifier do
   context "with RSA" do
     let(:request) do
-      request_data = Linzer::RFC9421::Examples.test_request_data
-      path = request_data[:http]["path"]
-      headers = request_data[:headers].merge({
-        "Forwarded" => "for=192.0.2.123;host=example.com;proto=https"
-      })
-      request = Linzer::Test::RackHelper.new_request(:post, path, {}, headers)
-      # Workaround the fact that `rack` reports a different `@authority`
-      # than this example from RFC9421 expects
-      allow(request).to receive(:authority).and_return("origin.host.internal.example")
-      request
+      Linzer::Test::RequestHelper.example_proxy_request
     end
 
     let(:key_material) { Linzer::RFC9421::Examples.test_key_rsa_pub }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require "securerandom"
 require "linzer"
 require_relative "rfc9421_examples"
 require_relative "rack_helper"
+require_relative "request_helper"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Replace `Rack::Request` usage in those tests with a more appropiate alternative, just plain old subclasses of `Net::HTTPRequest`.
    
This PR addresses one particular workaround that @oneiros needed to introduce when working on fixing some bugs with RSA signatures handling.
    
More context in https://github.com/nomadium/linzer/issues/11