### PR TITLE
Security: Use constant-time comparison for HMAC verification

### DIFF
--- a/lib/linzer/hmac.rb
+++ b/lib/linzer/hmac.rb
@@ -14,8 +14,16 @@ module Linzer
         OpenSSL::HMAC.digest(@params[:digest], material, data)
       end
 
+      # Verifies an HMAC signature using constant-time comparison.
+      #
+      # Uses OpenSSL.secure_compare to prevent timing attacks where an
+      # attacker could measure response times to guess valid signatures.
+      #
+      # @param signature [String] The signature bytes to verify
+      # @param data [String] The data that was signed
+      # @return [Boolean] true if the signature is valid, false otherwise
       def verify(signature, data)
-        signature == sign(data)
+        OpenSSL.secure_compare(signature, sign(data))
       end
 
       def private?

--- a/spec/hmac_sha256_spec.rb
+++ b/spec/hmac_sha256_spec.rb
@@ -21,6 +21,56 @@ RSpec.describe Linzer do
   end
 end
 
+RSpec.describe Linzer::HMAC::Key do
+  describe "#verify" do
+    it "uses constant-time comparison to prevent timing attacks" do
+      key = Linzer.generate_hmac_sha256_key
+      data = "test data"
+      valid_signature = key.sign(data)
+
+      # Verify that OpenSSL.secure_compare is being used
+      expect(OpenSSL).to receive(:secure_compare)
+        .with(valid_signature, valid_signature)
+        .and_call_original
+
+      expect(key.verify(valid_signature, data)).to eq(true)
+    end
+
+    it "returns true for valid signatures" do
+      key = Linzer.generate_hmac_sha256_key
+      data = "test data"
+      signature = key.sign(data)
+
+      expect(key.verify(signature, data)).to eq(true)
+    end
+
+    it "returns false for invalid signatures" do
+      key = Linzer.generate_hmac_sha256_key
+      data = "test data"
+      invalid_signature = "invalid" * 4 # 28 bytes, different from 32-byte HMAC
+
+      expect(key.verify(invalid_signature, data)).to eq(false)
+    end
+
+    it "returns false for tampered data" do
+      key = Linzer.generate_hmac_sha256_key
+      data = "test data"
+      signature = key.sign(data)
+
+      expect(key.verify(signature, "tampered data")).to eq(false)
+    end
+
+    it "returns false for signature from different key" do
+      key1 = Linzer.generate_hmac_sha256_key
+      key2 = Linzer.generate_hmac_sha256_key
+      data = "test data"
+      signature = key1.sign(data)
+
+      expect(key2.verify(signature, data)).to eq(false)
+    end
+  end
+end
+
 RSpec.describe Linzer::Signer do
   context "with HMAC using SHA-256" do
     let(:request) do


### PR DESCRIPTION
Fix potential timing attack vulnerability in HMAC signature verification.

The previous implementation used Ruby's == operator for comparing signatures:

    signature == sign(data)

This is vulnerable to timing attacks because == performs byte-by-byte comparison and returns false as soon as it finds a mismatch. An attacker can measure response times to determine how many leading bytes of their forged signature match the valid signature, potentially allowing them to construct a valid signature over many requests.

The fix uses OpenSSL.secure_compare which performs constant-time comparison:

    OpenSSL.secure_compare(signature, sign(data))

This always takes the same amount of time regardless of where (or if) the strings differ, preventing timing-based information leakage.

Changes:
- Replace == with OpenSSL.secure_compare in HMAC::Key#verify
- Add tests verifying the secure comparison is used
- Add tests for various HMAC verification scenarios

Security Impact:
- Mitigates CWE-208: Observable Timing Discrepancy
- No functional changes to signature verification behavior
- Compatible with existing OpenSSL >= 3.0 requirement

References:
- https://cwe.mitre.org/data/definitions/208.html
- https://codahale.com/a-lesson-in-timing-attacks/