### PR TITLE
Refactor HTTP structured field handling to centralize Starry dependency

### DIFF
--- a/lib/linzer.rb
+++ b/lib/linzer.rb
@@ -6,6 +6,8 @@ require "uri"
 require "net/http"
 
 require_relative "linzer/version"
+require_relative "linzer/http"
+require_relative "linzer/http/structured_field"
 require_relative "linzer/common"
 require_relative "linzer/signature/context"
 require_relative "linzer/signature/profile"
@@ -27,8 +29,6 @@ require_relative "linzer/ecdsa"
 require_relative "linzer/key/helper"
 require_relative "linzer/signer"
 require_relative "linzer/verifier"
-require_relative "linzer/http"
-require_relative "linzer/http/structured_field"
 
 # Linzer is a Ruby library for HTTP Message Signatures as defined in RFC 9421.
 #

--- a/lib/linzer/common.rb
+++ b/lib/linzer/common.rb
@@ -67,7 +67,7 @@ module Linzer
     # @param serialized_components [Array<String>] The covered components
     # @param parameters [Hash] Signature parameters
     # @return [String] The formatted @signature-params line
-    SERIALIZED_SIGNATURE_PARAMS = Starry.serialize("@signature-params").freeze
+    SERIALIZED_SIGNATURE_PARAMS = HTTP::StructuredField.serialize("@signature-params").freeze
     private_constant :SERIALIZED_SIGNATURE_PARAMS
 
     def signature_params_line(serialized_components, parameters)
@@ -136,7 +136,7 @@ module Linzer
           .flat_map
           .with_index do |group, idx|
             group
-              .map  { |comp| Starry.parse_item(idx.zero? ? comp[1..] : comp) }
+              .map  { |comp| HTTP::StructuredField.parse_item(idx.zero? ? comp[1..] : comp) }
               .uniq { |comp| [comp.value, comp.parameters] }
           end
 

--- a/lib/linzer/http/structured_field.rb
+++ b/lib/linzer/http/structured_field.rb
@@ -10,32 +10,135 @@ module Linzer
     # @see https://www.rfc-editor.org/rfc/rfc8941 RFC 8941
     # @see https://www.rfc-editor.org/rfc/rfc9421 RFC 9421
     module StructuredField
-      # Serializes HTTP Structured Field parameters according to RFC 8941.
+      InnerList  = Starry::InnerList
+      Item       = Starry::Item
+
+      # Parses an RFC 8941 Structured Field Dictionary.
       #
-      # This is primarily used for HTTP Message Signature parameters defined
-      # by RFC 9421.
-      #
-      # Serialization is delegated to `Starry.serialize_parameters` to ensure
-      # proper RFC-compliant encoding and quoting behavior for structured
-      # field values.
-      #
-      # @example Serialize signature parameters
-      #   StructuredField.serialize_parameters(
-      #     created: 1700000000,
-      #     keyid: "my-key"
-      #   )
-      #   # => ';created=1700000000;keyid="my-key"'
-      #
-      # @param parameters [Hash{Symbol,String => Object}]
-      #   The parameters to serialize as structured field parameters.
-      #
-      # @return [String]
-      #   The serialized structured field parameter string.
+      # @param str [String] the serialized dictionary value
+      # @param field_name [String, nil] optional field name for contextual errors
+      # @return [Hash<String, Object>] parsed structured field dictionary
+      # @raise [Linzer::Error] if the field cannot be parsed
       #
       # @see https://www.rfc-editor.org/rfc/rfc8941 RFC 8941
-      # @see https://www.rfc-editor.org/rfc/rfc9421 RFC 9421
+      def self.parse_dictionary(str, field_name: nil)
+        Starry.parse_dictionary(str)
+      # rescue Starry::ParseError => ex
+      # https://github.com/takemar/starry/pull/4
+      rescue => ex
+        cannot_parse = "Cannot parse %sfield!"
+        raise Error,
+              cannot_parse % [field_name ? "\"#{field_name}\" " : nil],
+              cause: ex
+      end
+
+      # Parses an RFC 8941 Structured Field Item.
+      #
+      # @param item [String] serialized structured field item
+      # @return [Starry::Item] parsed structured field item
+      # @raise [Linzer::Error] if the item is invalid or unparseable
+      #
+      # @see https://www.rfc-editor.org/rfc/rfc8941 RFC 8941
+      def self.parse_item(item)
+        Starry.parse_item(item)
+      # rescue Starry::ParseError => ex
+      # https://github.com/takemar/starry/pull/4
+      rescue => ex
+        raise Error, "Invalid/unparseable HTTP field item", cause: ex
+      end
+
+      # Parses an RFC 8941 Structured Field List.
+      #
+      # @param list [String] serialized structured field list
+      # @return [Array<Object>] parsed structured field list members
+      # @raise [Linzer::Error] if the list is invalid or unparseable
+      #
+      # @see https://www.rfc-editor.org/rfc/rfc8941 RFC 8941
+      def self.parse_list(list)
+        Starry.parse_list(list)
+      # rescue Starry::ParseError => ex
+      # https://github.com/takemar/starry/pull/4
+      rescue => ex
+        raise Error, "Invalid/unparseable HTTP field list", cause: ex
+      end
+
+      # Serializes a dictionary into RFC 8941 Structured Field format.
+      #
+      # @param hsh [Hash] structured field dictionary
+      # @return [String] serialized structured field dictionary
+      # @raise [Linzer::Error] if the dictionary cannot be serialized
+      #
+      # @see https://www.rfc-editor.org/rfc/rfc8941 RFC 8941
+      def self.serialize_dictionary(hsh)
+        Starry.serialize_dictionary(hsh)
+      # rescue Starry::SerializeError => ex
+      # https://github.com/takemar/starry/pull/4
+      rescue => ex
+        raise Error, ex.message, cause: ex
+      end
+
+      # Serializes a list into RFC 8941 Structured Field format.
+      #
+      # @param arr [Array] structured field list members
+      # @return [String] serialized structured field list
+      # @raise [Linzer::Error] if the list cannot be serialized
+      #
+      # @see https://www.rfc-editor.org/rfc/rfc8941 RFC 8941
+      def self.serialize_list(arr)
+        Starry.serialize_list(arr)
+      # rescue Starry::SerializeError => ex
+      # https://github.com/takemar/starry/pull/4
+      rescue => ex
+        raise Error, ex.message, cause: ex
+      end
+
+      # Serializes an object into RFC 8941 Structured Field format.
+      #
+      # @param obj [Object] structured field value
+      # @return [String] serialized structured field value
+      # @raise [Linzer::Error] if the object cannot be serialized
+      #
+      # @see https://www.rfc-editor.org/rfc/rfc8941 RFC 8941
+      def self.serialize(obj)
+        Starry.serialize(obj)
+      rescue Starry::SerializeError => ex
+        raise Error, ex.message, cause: ex
+      end
+
+      # Serializes a Structured Field Item into RFC 8941 format.
+      #
+      # This helper serializes a single Structured Field Item, such as
+      # a string, integer, token, boolean, date, byte sequence, or
+      # an already constructed {Starry::Item}.
+      #
+      # @param item [Object] structured field item value
+      # @return [String] serialized structured field item
+      # @raise [Linzer::Error] if the item cannot be serialized
+      #
+      # @see https://www.rfc-editor.org/rfc/rfc8941 RFC 8941
+      def self.serialize_item(item)
+        Starry.serialize_item(item)
+      rescue Starry::SerializeError => ex
+        raise Error, ex.message, cause: ex
+      end
+
+      # Serializes Structured Field Parameters into RFC 8941 format.
+      #
+      # Parameters are serialized according to the Structured Fields
+      # parameter syntax defined in RFC 8941 Section 3.1.2.
+      #
+      # @param parameters [Hash{String,Symbol => Object}] parameter names
+      #   and values
+      # @return [String] serialized structured field parameters
+      # @raise [Linzer::Error] if the parameters cannot be serialized
+      #
+      # @see https://www.rfc-editor.org/rfc/rfc8941 RFC 8941
       def self.serialize_parameters(parameters)
         Starry.serialize_parameters(parameters)
+      # rescue Starry::SerializeError => ex
+      # https://github.com/takemar/starry/pull/4
+      rescue => ex
+        raise Error, ex.message, cause: ex
       end
     end
   end

--- a/lib/linzer/message/adapter/abstract.rb
+++ b/lib/linzer/message/adapter/abstract.rb
@@ -108,10 +108,16 @@ module Linzer
           if !has_signature?
             signature_headers.each { |h, v| set_header!(h, v) }
           else
-            signature_headers.each do |hdr, value|
-              merged = Starry.parse_dictionary(String(header(hdr)))
-              merged.merge!(Starry.parse_dictionary(value))
-              set_header!(hdr, Starry.serialize_dictionary(merged))
+            begin
+              signature_headers.each do |hdr, value|
+                merged = HTTP::StructuredField.parse_dictionary(String(header(hdr)))
+                merged.merge!(HTTP::StructuredField.parse_dictionary(value))
+                set_header!(hdr, HTTP::StructuredField.serialize_dictionary(merged))
+              end
+            rescue Error => ex
+              raise Error,
+                    "Cannot attach signature, invalid signature header(s)!",
+                    cause: ex
             end
           end
 
@@ -120,10 +126,6 @@ module Linzer
           end
 
           @operation
-        rescue Starry::ParseError => e
-          raise Error,
-                "Cannot attach signature, invalid signature header(s)!",
-                cause: e
         end
 
         private
@@ -208,8 +210,9 @@ module Linzer
           has_bs  = name.parameters["bs"]
 
           if has_req
-            request_field = Starry::Item.new(name.value,
-                                             name.parameters.except("req"))
+            request_field =
+              HTTP::StructuredField::Item.new(name.value,
+                                              name.parameters.except("req"))
             return req(request_field, method)
           end
 
@@ -231,18 +234,15 @@ module Linzer
         # @return [String] the serialized structured field value
         # @see https://www.rfc-editor.org/rfc/rfc9421.html#section-2.1.1
         def sf(value, key = nil)
-          dict = Starry.parse_dictionary(value)
+          dict = HTTP::StructuredField.parse_dictionary(value)
 
           if key
             obj = dict[key]
-            Starry.serialize(obj.is_a?(Starry::InnerList) ? [obj] : obj)
+            HTTP::StructuredField.serialize(obj.is_a?(HTTP::StructuredField::InnerList) ? [obj] : obj)
           else
-            Starry.serialize(dict)
+            HTTP::StructuredField.serialize(dict)
           end
-        rescue => _ex
-          # XXX: TODO: rescue Starry::ParseError once
-          # https://github.com/takemar/starry/pull/4 is released or
-          # Starry related method calls are refactored.
+        rescue Error => _ex
           nil
         end
 
@@ -252,7 +252,7 @@ module Linzer
         # @return [String] the serialized byte sequence
         # @see https://www.rfc-editor.org/rfc/rfc9421.html#section-2.1.3
         def bs(value)
-          Starry.serialize(value.encode(Encoding::ASCII_8BIT))
+          HTTP::StructuredField.serialize(value.encode(Encoding::ASCII_8BIT))
         end
 
         # Retrieves a trailer field value.

--- a/lib/linzer/message/field.rb
+++ b/lib/linzer/message/field.rb
@@ -34,7 +34,7 @@ module Linzer
         # @raise [Error] If the component identifier is invalid
         def serialize
           raise Error, "Invalid component identifier: '#{field_name}'!" unless item
-          @serialized || Starry.serialize(@item)
+          @serialized || HTTP::StructuredField.serialize(@item)
         end
       end
 
@@ -113,7 +113,7 @@ module Linzer
                 # build the Item and serialized string directly,
                 # bypassing Starry.parse_item + Starry.serialize
                 quoted = "\"#{c}\""
-                item   = Starry::Item.new(c, {})
+                item   = HTTP::StructuredField::Item.new(c, {})
                 field_ids[i]  = FastIdentifier.new(quoted, item)
                 serialized[i] = quoted
               end
@@ -127,8 +127,8 @@ module Linzer
           # @return [Array<String>] Component names
           def deserialize_components(components)
             components.map do |c|
-              item = Starry.parse_item(c)
-              item.parameters.empty? ? item.value : Starry.serialize(item)
+              item = HTTP::StructuredField.parse_item(c)
+              item.parameters.empty? ? item.value : HTTP::StructuredField.serialize(item)
             end
           end
         end

--- a/lib/linzer/message/field/parser.rb
+++ b/lib/linzer/message/field/parser.rb
@@ -24,15 +24,15 @@ module Linzer
           def parse(field_name)
             case
             when field_name.match?(/";/), field_name.start_with?('"')
-              Starry.parse_item(field_name)
+              HTTP::StructuredField.parse_item(field_name)
             when field_name.match?(/;/)
               parse_unserialized_input(field_name)
             when field_name.start_with?("@"), field_name.match?(/^[a-z]/)
-              Starry.parse_item(Starry.serialize(field_name))
+              HTTP::StructuredField.parse_item(HTTP::StructuredField.serialize(field_name))
             else
               raise Error, "Invalid component identifier: '#{field_name}'!"
             end
-          rescue Starry::ParseError => ex
+          rescue Error => ex
             parse_error = "Failed to parse component identifier: '#{field_name}'!"
             raise Error, parse_error, cause: ex
           end
@@ -49,7 +49,7 @@ module Linzer
           # @return [Starry::Item] the parsed item with parameters
           def parse_unserialized_input(field_name)
             field, *raw_params = field_name.split(";")
-            item               = Starry.parse_item(Starry.serialize(field))
+            item               = HTTP::StructuredField.parse_item(HTTP::StructuredField.serialize(field))
             item.parameters    = collect_parameters(raw_params)
             item
           end
@@ -67,7 +67,7 @@ module Linzer
                 {param => true}
               else
                 Hash[*tokens.first(2)]                  # e.g.: ";key=\"foo\""
-                  .transform_values! { |v| Starry.parse_item(v).value }
+                  .transform_values! { |v| HTTP::StructuredField.parse_item(v).value }
               end
             end
             params.reduce({}, :merge)

--- a/lib/linzer/signature.rb
+++ b/lib/linzer/signature.rb
@@ -150,11 +150,11 @@ module Linzer
     def to_h
       return @headers if @headers
 
-      items = @parsed_items || serialized_components.map { |c| Starry.parse_item(c) }
+      items = @parsed_items || serialized_components.map { |c| HTTP::StructuredField.parse_item(c) }
       {
-        "signature"       => Starry.serialize({label => value}),
-        "signature-input" => Starry.serialize({
-          label => Starry::InnerList.new(items, parameters)
+        "signature"       => HTTP::StructuredField.serialize({label => value}),
+        "signature-input" => HTTP::StructuredField.serialize({
+          label => HTTP::StructuredField::InnerList.new(items, parameters)
         })
       }
     end
@@ -168,7 +168,7 @@ module Linzer
           # Clone items that have parameters since the adapter's retrieve
           # method may mutate parameters (e.g., deleting "req").
           unless item.parameters.empty?
-            item = Starry::Item.new(item.value, item.parameters.dup)
+            item = HTTP::StructuredField::Item.new(item.value, item.parameters.dup)
           end
           Message::Field::FastIdentifier.new(serialized, item)
         end
@@ -237,7 +237,11 @@ module Linzer
         headers.transform_values! { |v| v.encode(Encoding::ASCII) }
         validate headers
 
-        input = parse_structured_field(headers, "signature-input")
+        input = HTTP::StructuredField.parse_dictionary(
+          headers["signature-input"],
+          field_name: "signature-input"
+        )
+
         reject_multiple_signatures if input.size > 1 && options[:label].nil?
         label = options[:label] || input.keys.first
 
@@ -317,16 +321,17 @@ module Linzer
         end
 
         # Label not found via fast path — fall back to Starry
-        signature = parse_structured_dictionary(
-          value.encode(Encoding::US_ASCII), "signature"
+        signature = HTTP::StructuredField.parse_dictionary(
+          value.encode(Encoding::US_ASCII),
+          field_name: "signature"
         )
         fail_with_signature_not_found label unless signature.key?(label)
         signature[label].value.force_encoding(Encoding::ASCII_8BIT)
       rescue ArgumentError
         # Base64 decode failed — fall back to Starry
-        signature = parse_structured_dictionary(
-          value.encode(Encoding::US_ASCII), "signature"
-        )
+        signature = HTTP::StructuredField.parse_dictionary(
+          value.encode(Encoding::US_ASCII),
+          field_name: "signature")
         fail_with_signature_not_found label unless signature.key?(label)
         signature[label].value.force_encoding(Encoding::ASCII_8BIT)
       end
@@ -345,22 +350,7 @@ module Linzer
       #   The serialized structured field item representations.
       #
       def serialize_parsed_items(items)
-        items.map { |item| Starry.serialize_item(item) }
-      end
-
-      def parse_structured_dictionary(str, field_name = nil)
-        Starry.parse_dictionary(str)
-      rescue Starry::ParseError => _
-        raise Error.new "Cannot parse \"#{field_name}\" field. Bailing out!"
-      end
-
-      # Parses a structured field value as a dictionary.
-      # @see https://datatracker.ietf.org/doc/html/rfc8941 RFC 8941
-      def parse_structured_field(hsh, field_name)
-        # Serialized Structured Field values for HTTP are ASCII strings.
-        # See: RFC 8941 (https://datatracker.ietf.org/doc/html/rfc8941)
-        value = hsh[field_name].encode(Encoding::US_ASCII)
-        parse_structured_dictionary(value, field_name)
+        items.map { |item| HTTP::StructuredField.serialize_item(item) }
       end
     end
   end

--- a/lib/linzer/signature/profile/web_bot_auth.rb
+++ b/lib/linzer/signature/profile/web_bot_auth.rb
@@ -163,18 +163,16 @@ module Linzer
         def set_agent!(agent, label, message, components, overlay_headers)
           if message[SIGNATURE_AGENT] != agent
             overlay_headers[SIGNATURE_AGENT] =
-              Starry.serialize_dictionary(label => agent)
+              HTTP::StructuredField.serialize_dictionary(label => agent)
 
-            field = Starry::Item.new(SIGNATURE_AGENT, key: label)
-            serialized_field = Starry.serialize(field)
+            field = HTTP::StructuredField::Item.new(SIGNATURE_AGENT, key: label)
+            serialized_field = HTTP::StructuredField.serialize(field)
             if !components.include?(serialized_field)
               components << serialized_field
             end
           end
-        rescue Starry::SerializeError => ex
-          raise Error,
-                "Invalid #{SIGNATURE_AGENT} header value!",
-                cause: ex
+        rescue Error => ex
+          raise Error, "Invalid #{SIGNATURE_AGENT} header value!", cause: ex
         end
 
         # Validates that the context is compatible with Web Bot Auth.

--- a/spec/http/structured_field_spec.rb
+++ b/spec/http/structured_field_spec.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+RSpec.describe Linzer::HTTP::StructuredField do
+  describe ".parse_dictionary" do
+    let(:input) { "sig1=:AQIDBA==:" }
+
+    it "delegates to Starry.parse_dictionary" do
+      expect(Starry)
+        .to receive(:parse_dictionary)
+        .with(input)
+
+      described_class.parse_dictionary(input)
+    end
+
+    it "returns the parsed dictionary" do
+      result = described_class.parse_dictionary(input)
+
+      expect(result).to      be_a(Hash)
+      expect(result.keys).to eq(["sig1"])
+    end
+
+    it "raises Linzer::Error on parse failure" do
+      allow(Starry)
+        .to receive(:parse_dictionary)
+        .and_raise(StandardError.new("boom"))
+
+      expect { described_class.parse_dictionary("invalid") }
+        .to raise_error(Linzer::Error, "Cannot parse field!")
+    end
+
+    it "includes the field name in raised errors" do
+      allow(Starry)
+        .to receive(:parse_dictionary)
+        .and_raise(StandardError.new("boom"))
+
+      expect { described_class.parse_dictionary("invalid", field_name: "signature-input") }
+        .to raise_error(Linzer::Error, 'Cannot parse "signature-input" field!')
+    end
+  end
+
+  describe ".parse_item" do
+    let(:input) { '"@method"' }
+
+    it "delegates to Starry.parse_item" do
+      expect(Starry)
+        .to receive(:parse_item)
+        .with(input)
+
+      described_class.parse_item(input)
+    end
+
+    it "returns a parsed item" do
+      item = described_class.parse_item(input)
+
+      expect(item).to       be_a(Starry::Item)
+      expect(item.value).to eq("@method")
+    end
+
+    it "raises Linzer::Error on invalid items" do
+      allow(Starry)
+        .to receive(:parse_item)
+        .and_raise(StandardError.new("boom"))
+
+      expect { described_class.parse_item("bad") }
+        .to raise_error(Linzer::Error, "Invalid/unparseable HTTP field item")
+    end
+  end
+
+  describe ".parse_list" do
+    let(:input) { '("date" "host")' }
+
+    it "delegates to Starry.parse_list" do
+      expect(Starry)
+        .to receive(:parse_list)
+        .with(input)
+
+      described_class.parse_list(input)
+    end
+
+    it "returns parsed list values" do
+      result = described_class.parse_list(input)
+
+      expect(result).to       be_an(Array)
+      expect(result.first).to be_a(Starry::InnerList)
+    end
+
+    it "raises Linzer::Error on invalid lists" do
+      allow(Starry)
+        .to receive(:parse_list)
+        .and_raise(StandardError.new("boom"))
+
+      expect { described_class.parse_list("bad") }
+        .to raise_error(Linzer::Error, "Invalid/unparseable HTTP field list")
+    end
+  end
+
+  describe ".serialize_dictionary" do
+    let(:value) { {"foo" => "bar"} }
+
+    it "delegates to Starry.serialize_dictionary" do
+      expect(Starry)
+        .to receive(:serialize_dictionary)
+        .with(value)
+
+      described_class.serialize_dictionary(value)
+    end
+
+    it "serializes dictionaries" do
+      expect(described_class.serialize_dictionary(value)).to eq('foo="bar"')
+    end
+
+    it "wraps serialization errors" do
+      allow(Starry)
+        .to receive(:serialize_dictionary)
+        .and_raise(Starry::SerializeError.new("boom"))
+
+      expect { described_class.serialize_dictionary(value) }
+        .to raise_error(Linzer::Error, "boom")
+    end
+  end
+
+  describe ".serialize_list" do
+    let(:value) { ["foo", "bar"] }
+
+    it "delegates to Starry.serialize_list" do
+      expect(Starry)
+        .to receive(:serialize_list)
+        .with(value)
+
+      described_class.serialize_list(value)
+    end
+
+    it "serializes lists" do
+      expect(described_class.serialize_list(value)).to eq('"foo", "bar"')
+    end
+
+    it "wraps serialization errors" do
+      allow(Starry)
+        .to receive(:serialize_list)
+        .and_raise(StandardError.new("boom"))
+
+      expect { described_class.serialize_list(value) }
+        .to raise_error(Linzer::Error, "boom")
+    end
+  end
+
+  describe ".serialize_item" do
+    subject(:serialize_item) { described_class.serialize_item(item) }
+
+    let(:item) { "hello" }
+
+    it "delegates to Starry.serialize_item" do
+      expect(Starry).to receive(:serialize_item)
+        .with(item)
+        .and_return('"hello"')
+
+      serialize_item
+    end
+
+    it "returns the serialized item" do
+      allow(Starry).to receive(:serialize_item)
+        .with(item)
+        .and_return('"hello"')
+
+      expect(serialize_item).to eq('"hello"')
+    end
+
+    context "when Starry raises SerializeError" do
+      let(:starry_error) do
+        Starry::SerializeError.new("unable to serialize item")
+      end
+
+      before do
+        allow(Starry).to receive(:serialize_item)
+          .with(item)
+          .and_raise(starry_error)
+      end
+
+      it "raises Linzer::Error with the same message" do
+        expect { serialize_item }
+          .to raise_error(Linzer::Error, "unable to serialize item")
+      end
+
+      it "preserves the original exception as the cause" do
+        expect do
+          serialize_item
+        rescue Linzer::Error => ex
+          expect(ex.cause).to be(starry_error)
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe ".serialize" do
+    let(:value) { {"foo" => "bar"} }
+
+    it "delegates to Starry.serialize" do
+      expect(Starry)
+        .to receive(:serialize)
+        .with(value)
+
+      described_class.serialize(value)
+    end
+
+    it "serializes objects" do
+      expect(described_class.serialize(value)).to eq('foo="bar"')
+    end
+
+    it "wraps serialization errors" do
+      allow(Starry)
+        .to receive(:serialize)
+        .and_raise(Starry::SerializeError.new("boom"))
+
+      expect { described_class.serialize(value) }
+        .to raise_error(Linzer::Error, "boom")
+    end
+  end
+
+  describe ".serialize_parameters" do
+    it "serializes integer parameters" do
+      result = described_class.serialize_parameters(created: 1700000000)
+
+      expect(result).to eq(";created=1700000000")
+    end
+
+    it "serializes string parameters" do
+      result = described_class.serialize_parameters(keyid: "my-key")
+
+      expect(result).to eq(';keyid="my-key"')
+    end
+
+    it "serializes mixed parameters" do
+      result = described_class.serialize_parameters(
+        created: 1700000000,
+        keyid: "test-key",
+        alg: "ed25519"
+      )
+
+      expect(result).to eq(';created=1700000000;keyid="test-key";alg="ed25519"')
+    end
+
+    it "returns an empty string for empty parameters" do
+      expect(described_class.serialize_parameters({})).to eq("")
+    end
+
+    it "raises Linzer::Error on serialization failure" do
+      expect { described_class.serialize_parameters(nil) }
+        .to raise_error(Linzer::Error)
+    end
+  end
+end

--- a/spec/integration/responses_spec.rb
+++ b/spec/integration/responses_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Signature verification on responses", :integration do
   end
 
   def content_digest(data)
-    Starry.serialize("sha-256" => Digest::SHA256.digest(data))
+    Linzer::HTTP::StructuredField.serialize("sha-256" => Digest::SHA256.digest(data))
   end
 
   let(:port) { @web_server.port }

--- a/spec/integration/support/test_app.rb
+++ b/spec/integration/support/test_app.rb
@@ -53,7 +53,7 @@ module Linzer
         end
 
         def content_digest(data)
-          Starry.serialize("sha-256" => Digest::SHA256.digest(data))
+          Linzer::HTTP::StructuredField.serialize("sha-256" => Digest::SHA256.digest(data))
         end
 
         def keys_directory

--- a/spec/message/adapter/generic/request_spec.rb
+++ b/spec/message/adapter/generic/request_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Linzer::Message::Adapter::Generic::Request do
 
         # There should be exactly one "sig1" entry, not two
         sig_headers = request.each_header.to_h.slice("signature", "signature-input")
-        parsed = Starry.parse_dictionary(sig_headers["signature"])
+        parsed = Linzer::HTTP::StructuredField.parse_dictionary(sig_headers["signature"])
 
         expect(parsed.keys).to eq(["sig1"])
       end

--- a/spec/message/adapter/generic/response_spec.rb
+++ b/spec/message/adapter/generic/response_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Linzer::Message::Adapter::Generic::Response do
 
         # There should be exactly one "sig1" entry, not two
         sig_headers = response.each_header.to_h.slice("signature", "signature-input")
-        parsed = Starry.parse_dictionary(sig_headers["signature"])
+        parsed = Linzer::HTTP::StructuredField.parse_dictionary(sig_headers["signature"])
 
         expect(parsed.keys).to eq(["sig1"])
       end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 def build_random_signature(label)
-  Starry.serialize_dictionary({label => SecureRandom.random_bytes(64)})
+  Linzer::HTTP::StructuredField.serialize_dictionary({label => SecureRandom.random_bytes(64)})
 end
 
 RSpec.describe "README usage" do

--- a/spec/rfc9421_spec.rb
+++ b/spec/rfc9421_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe "RFC9421" do
       serialized_params = '("@target-uri" "@authority" "date" "cache-control")' \
                           ';keyid="test-key-rsa-pss";alg="rsa-pss-sha512";' \
                           "created=1618884475;expires=1618884775"
-      signature_params = Starry.parse_list(serialized_params).shift
+      signature_params = Linzer::HTTP::StructuredField.parse_list(serialized_params).shift
 
       parameters = signature_params.parameters
       expect(parameters["keyid"]).to   eq("test-key-rsa-pss")
@@ -453,8 +453,8 @@ RSpec.describe "RFC9421" do
         '"@authority";req "@method";req "@path";req "content-digest";req)' \
         ';created=1618884479;keyid="test-key-ecc-p256"'
 
-      signature_params = Starry.parse_list(serialized_signature_params).shift
-      components = signature_params.value.map { |i| Starry.serialize(i) }
+      signature_params = Linzer::HTTP::StructuredField.parse_list(serialized_signature_params).shift
+      components = signature_params.value.map { |i| Linzer::HTTP::StructuredField.serialize(i) }
       parameters = signature_params.parameters
 
       expect(Linzer.signature_base(message, components, parameters))
@@ -501,7 +501,7 @@ RSpec.describe "RFC9421" do
       serialized_components = Linzer::FieldId.serialize_components(components)
 
       parameters = {"created" => 1618884473, "keyid" => "test-key-rsa-pss"}
-      signature_params = Starry.serialize_list([Starry::InnerList.new(components, parameters)])
+      signature_params = Linzer::HTTP::StructuredField.serialize_list([Linzer::HTTP::StructuredField::InnerList.new(components, parameters)])
 
       expected_content_digest = "sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX" \
                                 "+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:"
@@ -535,8 +535,8 @@ RSpec.describe "RFC9421" do
     def signature_headers(b64_signature, components = [], parameters = {}, label = "sig1")
       {
         "signature"       => Base64.strict_decode64(b64_signature),
-        "signature-input" => Starry::InnerList.new(components, parameters)
-      }.transform_values! { |v| Starry.serialize(String(label) => v) }
+        "signature-input" => Linzer::HTTP::StructuredField::InnerList.new(components, parameters)
+      }.transform_values! { |v| Linzer::HTTP::StructuredField.serialize(String(label) => v) }
     end
 
     it "example signature value" do

--- a/spec/signature/profile/web_bot_auth_spec.rb
+++ b/spec/signature/profile/web_bot_auth_spec.rb
@@ -143,12 +143,12 @@ RSpec.describe Linzer::Signature::Profile::WebBotAuth do
           .with("signature-agent")
           .and_return(nil)
 
-        allow(Starry)
+        allow(Linzer::HTTP::StructuredField)
           .to receive(:serialize_dictionary)
           .with("sig1" => agent)
           .and_return('sig1="https://example.com/bot"')
 
-        allow(Starry)
+        allow(Linzer::HTTP::StructuredField)
           .to receive(:serialize)
           .and_return('"signature-agent";key="sig1"')
       end
@@ -198,19 +198,16 @@ RSpec.describe Linzer::Signature::Profile::WebBotAuth do
           .with("signature-agent")
           .and_return(nil)
 
-        allow(Starry)
+        allow(Linzer::HTTP::StructuredField)
           .to receive(:serialize_dictionary)
-          .and_raise(
-            Starry::SerializeError.new("boom")
-          )
+          .and_raise(Linzer::Error.new("boom"))
       end
 
       let(:params) { {label: "sig1"} }
 
       it "raises a Linzer::Error" do
         expect { apply_profile }
-          .to raise_error(
-            Linzer::Error,
+          .to raise_error(Linzer::Error,
             "Invalid signature-agent header value!"
           )
       end


### PR DESCRIPTION
- Refactor HTTP structured field handling to centralize Starry dependency
- Replace Starry with Linzer HTTP StructuredField in tests\