### PR TITLE
Fix Faraday adapter signing a re-encoded query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## [Unreleased]
 
+- Fix Faraday adapter deriving URI components from a re-encoded query
+  string, which could differ from the URI faraday actually sent and fail
+  verification at the origin. Affected `@target-uri`, `@request-target`
+  and `@query`. The query is now encoded with the request's own
+  `params_encoder`, so it tracks the URL faraday puts on the wire:
+
+  - Spaces no longer always encode as `+`. Faraday honours the
+    process-wide `Faraday::Utils.default_space_encoding`, which other
+    gems may set (the `oauth2` gem sets it to `"%20"` on load), so a
+    query value containing a space signed a URI the verifier could not
+    reproduce.
+
+  - A request with no query parameters no longer appends a stray `?`.
+
+  - A `params_encoder` configured on the connection or request is now
+    preserved, instead of being replaced with the default encoder.
+
 ## [0.8.0.beta2] - 2026-05-20
 
 - Add Web Bot Auth support, implementing the current IETF draft

--- a/lib/linzer/faraday/utils.rb
+++ b/lib/linzer/faraday/utils.rb
@@ -14,13 +14,20 @@ module Linzer
       # {Linzer::Message::Adapter::Faraday::Request}, preserving the
       # original HTTP method, URL, and headers from the environment.
       #
+      # Preserves the environment's request options when present, so that
+      # a +params_encoder+ configured on the connection or request is
+      # carried over. The adapter re-encodes query parameters when
+      # deriving +@target-uri+ and friends, and must use the same encoder
+      # Faraday used to write the URL, or the signed value will not match
+      # the URI actually sent.
+      #
       # @param env [::Faraday::Env] the middleware environment
       # @return [::Faraday::Request] a new request object
       def self.create_request(env)
         ::Faraday::Request.create(env.method) do |req|
           req.params  = ::Faraday::Utils::ParamsHash.new
           req.headers = ::Faraday::Utils::Headers.new(env.request_headers.dup)
-          req.options = ::Faraday::ConnectionOptions.from(nil).request
+          req.options = env.request || ::Faraday::ConnectionOptions.from(nil).request
           req.url       env.url
         end
       end

--- a/lib/linzer/message/adapter/faraday/request.rb
+++ b/lib/linzer/message/adapter/faraday/request.rb
@@ -37,10 +37,24 @@ module Linzer
 
           # Builds the full URI including query parameters.
           #
+          # Encodes the query with the request's own +params_encoder+,
+          # mirroring how faraday builds the URL it puts on the wire
+          # (+Faraday::Connection#build_env+). Encoding it independently
+          # here would diverge from the URI actually sent: notably
+          # +URI.encode_www_form+ always encodes a space as +++, while
+          # faraday honours the process-wide
+          # +Faraday::Utils.default_space_encoding+, which other gems may
+          # set to +%20+. The signer would then cover a +@target-uri+ the
+          # verifier cannot reproduce from the request it received.
+          #
+          # An empty query is left as +nil+ rather than +""+, as assigning
+          # +""+ would append a stray +?+ that faraday does not send.
+          #
           # @return [URI] the complete request URI with encoded query string
           def uri
             uri = @operation.path.dup
-            uri.query = URI.encode_www_form(@operation.params)
+            query = @operation.params.to_query(@operation.options.params_encoder)
+            uri.query = query unless query.empty?
             uri
           end
 

--- a/spec/faraday/http_signature/middleware_spec.rb
+++ b/spec/faraday/http_signature/middleware_spec.rb
@@ -242,4 +242,54 @@ RSpec.describe "Faraday::HttpSignature::Middleware" do
       end
     end
   end
+
+  context "signing URI-derived components" do
+    before(:all) { require "linzer/rack" }
+
+    let(:key) { Linzer.generate_ed25519_key("test-key") }
+    let(:components) { %w[@method @target-uri @request-target @query] }
+
+    # Signs a request through the middleware and re-verifies the signature
+    # against the URL that was actually put on the wire, as an origin server
+    # would: the signed URI-derived components must match the request sent.
+    def verify_round_trip(path, params = nil, request_options: nil)
+      wire_url = nil
+      conn = Faraday.new(url: "http://example.com", request: request_options) do |b|
+        b.request :http_signature, key: key, components: components
+        b.adapter :test do |stub|
+          stub.get(/.*/) do |env|
+            wire_url = env.url.to_s.dup
+            [200, {}, "ok"]
+          end
+        end
+      end
+
+      headers = conn.get(path, params).env.request_headers
+      env = Rack::MockRequest.env_for(wire_url, method: "GET").merge(
+        headers.to_h { |name, value| ["HTTP_#{name.tr("-", "_").upcase}", value] }
+      )
+      message = Linzer::Message.new(Rack::Request.new(env))
+
+      Linzer.verify(key, message, Linzer::Signature.build(headers))
+    end
+
+    it "verifies against the URI sent when a param value contains a space" do
+      # `URI.encode_www_form` renders a space as `+`, but faraday honours the
+      # process-wide `default_space_encoding`, which gems such as oauth2 set
+      # to "%20". The signed URI must follow whatever faraday sent.
+      Linzer::Test::FaradayHelper.with_space_encoding("%20") do
+        expect(verify_round_trip("/search", {q: "Kate Smith"})).to eq(true)
+      end
+    end
+
+    it "verifies against the URI sent when the request has no query params" do
+      expect(verify_round_trip("/search")).to eq(true)
+    end
+
+    it "verifies against the URI sent under a custom params_encoder" do
+      expect(
+        verify_round_trip("/search", {q: %w[a b]}, request_options: {params_encoder: Faraday::FlatParamsEncoder})
+      ).to eq(true)
+    end
+  end
 end

--- a/spec/faraday/utils_spec.rb
+++ b/spec/faraday/utils_spec.rb
@@ -25,5 +25,26 @@ RSpec.describe "Linzer::Faraday::Utils" do
       expect(request.path).to        eq(url)
       expect(request.headers).to     eq(headers)
     end
+
+    it "preserves the request options from the environment" do
+      env = Faraday::Env.new
+      env.method  = :get
+      env.url     = URI("https://www.example.com/")
+      env.request = Faraday::RequestOptions.from(params_encoder: Faraday::FlatParamsEncoder)
+
+      request = utils.create_request(env)
+
+      expect(request.options.params_encoder).to eq(Faraday::FlatParamsEncoder)
+    end
+
+    it "falls back to default request options when the environment has none" do
+      env = Faraday::Env.new
+      env.method = :get
+      env.url    = URI("https://www.example.com/")
+
+      request = utils.create_request(env)
+
+      expect(request.options).to be_a(Faraday::RequestOptions)
+    end
   end
 end

--- a/spec/faraday_helper.rb
+++ b/spec/faraday_helper.rb
@@ -9,6 +9,16 @@ module Linzer
         env = ::Faraday::Env.from(options)
         Linzer::Faraday::Utils.create_request(env)
       end
+
+      # Temporarily sets faraday's process-wide space encoding, restoring
+      # the previous value afterwards so it does not leak between examples.
+      def with_space_encoding(encoding)
+        previous = ::Faraday::Utils.default_space_encoding
+        ::Faraday::Utils.default_space_encoding = encoding
+        yield
+      ensure
+        ::Faraday::Utils.default_space_encoding = previous
+      end
     end
   end
 end

--- a/spec/message/adapter/faraday/request_spec.rb
+++ b/spec/message/adapter/faraday/request_spec.rb
@@ -49,6 +49,35 @@ RSpec.describe Linzer::Message::Adapter::Faraday::Request do
         adapter = described_class.new(request)
         expect(adapter["@target-uri"]).to eq("https://www.example.com/path?param=value")
       end
+
+      it "omits the query separator when the request has no query params" do
+        uri = URI("https://www.example.com/path")
+        request_attrs = {method: :get, url: uri}
+        request = Linzer::Test::FaradayHelper.new_request(request_attrs)
+        adapter = described_class.new(request)
+        expect(adapter["@target-uri"]).to eq("https://www.example.com/path")
+      end
+
+      it "encodes spaces the way faraday does, not as `+`" do
+        # Faraday writes the wire URL honouring the process-wide
+        # `default_space_encoding`; encoding independently here would sign a
+        # URI that differs from the one actually sent.
+        Linzer::Test::FaradayHelper.with_space_encoding("%20") do
+          uri = URI("https://www.example.com/search?q=Kate%20Smith")
+          request_attrs = {method: :get, url: uri}
+          request = Linzer::Test::FaradayHelper.new_request(request_attrs)
+          adapter = described_class.new(request)
+          expect(adapter["@target-uri"]).to eq("https://www.example.com/search?q=Kate%20Smith")
+        end
+      end
+
+      it "encodes the query with the request's own params_encoder" do
+        uri = URI("https://www.example.com/search?q=a&q=b")
+        request_attrs = {method: :get, url: uri, request: {params_encoder: Faraday::FlatParamsEncoder}}
+        request = Linzer::Test::FaradayHelper.new_request(request_attrs)
+        adapter = described_class.new(request)
+        expect(adapter["@target-uri"]).to eq("https://www.example.com/search?q=a&q=b")
+      end
     end
 
     context "@authority" do


### PR DESCRIPTION
## Problems

Faraday has a setting, `Faraday::Utils.default_space_encoding`, which allows you to choose how spaces are encoded.  Some gems, like `oauth2`, [change this setting by default](https://github.com/ruby-oauth/oauth2/blob/3f782f1f4a0ee0d01a567cdc21ab35d7590c2145/lib/oauth2/client.rb#L11):

```ruby
Faraday::Utils.default_space_encoding = "%20" # instead of "+"
```

The Faraday adapter currently derives `@target-uri`, `@request-target` and `@query` by discarding the request URI's query string and rebuilding it with `URI.encode_www_form`. `URI.encode_www_form` always renders a space as `+`, while Faraday writes the URL honouring `Faraday::Utils.default_space_encoding`.

The drift meant we had signature verification issues in practice simply by having `oauth2` sitting alongside `linzer`, because Faraday's `default_space_encoding` setting had been changed, and the adapter wasn't respecting it.

```
signer   → …?filter_by_name=Kate+Smith
verifier → …?filter_by_name=Kate%20Smith
```

We also found that empty parameters could lead to a trailing `?`:

```
request  → GET http://example.com/search (no params)
signer   → http://example.com/search?
verifier → http://example.com/search
```

This is because an empty query was being treated as `""` which lead to a trailing `"?"`.

And finally that duplicated params could differ between signer and verifier:

```
request  → GET http://example.com/search?q=a&q=b
signer   → http://example.com/search?q=b
verifier → http://example.com/search?q=a&q=b
```

`create_request` also replaced the environment's request options with fresh defaults, discarding any configured `params_encoder`. Beyond the encoding mismatch this lost data: under `FlatParamsEncoder`, array params sent as `q=a&q=b` were signed as `q=b` because they fell back to `NestedParamsEncoder`. 


## Fixes

1. Encode the query with the request's own `params_encoder` instead, mirroring how Faraday builds the URL in `Connection#build_env`. This respects `default_space_encoding`.
2. Treat an empty query as `nil` rather than `""` so a parameterless request no longer gains a stray trailing `"?"`.
3. Preserve `env.request` so the adapter encodes `FlatParamsEncoder` or `NestedParamsEncoder` the way the connection does.

## User impact

Should be safe: it patches cases where verification would have been broken before. Possible risk: if someone is using the same Faraday adapter for both signing _and_ verification, they need to make sure both sides make this upgrade at the same time. 

No change for signatures that don't cover `@target-uri`, `@request-target` or `@query`, or whose query encodes identically under both paths. For us, the bug only affected GET params where spaces were present, which is not most requests.